### PR TITLE
Testing ToDo filters

### DIFF
--- a/__tests__/todoFilter.spec.js
+++ b/__tests__/todoFilter.spec.js
@@ -1,0 +1,123 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import { userDataBuilder, itemDataBuilder } from 'dataBuilders';
+import { submitInput, submitMultiples } from 'submitInput';
+
+import Todo from '../src/screens/todo';
+
+const user = userDataBuilder();
+const todoItem = itemDataBuilder();
+
+test('should only show active items when using "ACTIVE" filter', () => {
+  // render the todo screen
+  const {
+    getByPlaceholderText,
+    getByText,
+    getByLabelText,
+    getAllByRole,
+    queryByText,
+  } = render(<Todo user={user} />);
+
+  // get to-do list and input
+  const todoList = getByLabelText(/todo-list/i);
+  const input = getByPlaceholderText(/What needs to be done?/i);
+
+  //* type in the input field & click submits multiple words
+  submitMultiples(input, todoItem.extraWords);
+
+  //* get one switch for each to-do item and toggle it
+  const switchArray = getAllByRole('switch');
+
+  switchArray.forEach((switchElement) => {
+    fireEvent(switchElement, 'onValueChange', true);
+  });
+
+  //* type in the input field & click submit sentence
+  submitInput(input, todoItem.sentence);
+
+  // Press ACTIVE filter
+  fireEvent.press(getByLabelText('show-active-items-button'));
+
+  expect(todoList).toContainElement(getByText(todoItem.sentence));
+
+  todoItem.extraWords.forEach((word) => {
+    expect(todoList).not.toContainElement(queryByText(word));
+    expect(queryByText(word)).toBeNull();
+  });
+});
+
+test('should only show completed items when using "COMPLETED" filter', () => {
+  // render the todo screen
+  const {
+    getByPlaceholderText,
+    getByText,
+    getByLabelText,
+    getAllByRole,
+    queryByText,
+  } = render(<Todo user={user} />);
+
+  // get to-do list and input
+  const todoList = getByLabelText(/todo-list/i);
+  const input = getByPlaceholderText(/What needs to be done?/i);
+
+  //* type in the input field & click submits multiple words
+  submitMultiples(input, todoItem.extraWords);
+
+  //* get one switch for each to-do item and toggle it
+  const switchArray = getAllByRole('switch');
+
+  switchArray.forEach((switchElement) => {
+    fireEvent(switchElement, 'onValueChange', true);
+  });
+
+  //* type in the input field & click submit sentence
+  submitInput(input, todoItem.sentence);
+
+  fireEvent.press(getByLabelText('show-completed-items-button'));
+
+  expect(todoList).not.toContainElement(queryByText(todoItem.sentence));
+  expect(queryByText(todoItem.sentence)).toBeNull();
+
+  todoItem.extraWords.forEach((word) => {
+    expect(todoList).toContainElement(getByText(word));
+  });
+});
+
+test('should show ALL items again after using the "ACTIVE" or "COMPLETED" filter', () => {
+  const { getByPlaceholderText, getByText, getByLabelText, getAllByRole } =
+    render(<Todo user={user} />);
+
+  // get to-do list and input
+  const todoList = getByLabelText(/todo-list/i);
+  const input = getByPlaceholderText(/What needs to be done?/i);
+
+  //* type in the input field & click submits multiple words
+  submitMultiples(input, todoItem.extraWords);
+
+  //* get one switch for each to-do item and toggle it
+  const switchArray = getAllByRole('switch');
+
+  switchArray.forEach((switchElement) => {
+    fireEvent(switchElement, 'onValueChange', true);
+  });
+
+  //* type in the input field & click submit sentence
+  submitInput(input, todoItem.sentence);
+
+  fireEvent.press(getByLabelText('show-completed-items-button'));
+  fireEvent.press(getByLabelText('show-all-items-button'));
+
+  expect(todoList).toContainElement(getByText(todoItem.sentence));
+  todoItem.extraWords.forEach((word) => {
+    expect(todoList).toContainElement(getByText(word));
+  });
+
+  // Press ACTIVE filter
+  fireEvent.press(getByLabelText('show-active-items-button'));
+  fireEvent.press(getByLabelText('show-all-items-button'));
+
+  expect(todoList).toContainElement(getByText(todoItem.sentence));
+  todoItem.extraWords.forEach((word) => {
+    expect(todoList).toContainElement(getByText(word));
+  });
+});

--- a/__tests__/userMenu.spec.js
+++ b/__tests__/userMenu.spec.js
@@ -14,11 +14,11 @@ afterEach(() => {
 
 test('button should call navigation.goBack() prop method', () => {
   const mockGoBack = jest.fn();
+
+  // render the todo screen
   const { getByText } = render(<Menu navigation={{ goBack: mockGoBack }} />);
 
-  const GoHomeButton = getByText(/go home/i);
-
-  fireEvent.press(GoHomeButton);
+  fireEvent.press(getByText(/go home/i));
 
   expect(mockGoBack).toHaveBeenCalled();
 });
@@ -26,9 +26,7 @@ test('button should call navigation.goBack() prop method', () => {
 test('button should call onSignOut function', () => {
   const { getByText } = render(<Menu />);
 
-  const LogOutButton = getByText(/sign out/i);
-
-  fireEvent.press(LogOutButton);
+  fireEvent.press(getByText(/sign out/i));
 
   expect(mockOnSignOut).toHaveBeenCalled();
 });

--- a/src/components/filter.js
+++ b/src/components/filter.js
@@ -10,6 +10,7 @@ const Footer = (props) => {
 
       <View style={styles.filters}>
         <TouchableOpacity
+          accessibilityLabel="show-all-items-button"
           style={[styles.filter, filter === 'ALL' && styles.selected]}
           onPress={() => props.onFilter('ALL')}
         >
@@ -17,6 +18,7 @@ const Footer = (props) => {
         </TouchableOpacity>
 
         <TouchableOpacity
+          accessibilityLabel="show-active-items-button"
           style={[styles.filter, filter === 'ACTIVE' && styles.selected]}
           onPress={() => props.onFilter('ACTIVE')}
         >
@@ -24,6 +26,7 @@ const Footer = (props) => {
         </TouchableOpacity>
 
         <TouchableOpacity
+          accessibilityLabel="show-completed-items-button"
           style={[styles.filter, filter === 'COMPLETED' && styles.selected]}
           onPress={() => props.onFilter('COMPLETED')}
         >


### PR DESCRIPTION
**What:**
Add test coverage for the `ToDo` screen of the Fais Le application
​
**Why:**
Current test coverage `ToDo` screen does not ensure that the filters use on the to-do list work as expected.
There no Issue releated to this Pull Request
​
**How:**
1. Add `AccessibilityLabel` prop to all the tested elements
2. Add test for when **"ACTIVE" filter is press**, so it shows only active items
3. Add test for when **"COMPLETE" filter is press**, so it shows only completed items
4. Add test for when **"ALL" filter is press after other filters were use**, so it shows all items again

​
**Extras:**

- Refactor `userMenu` test to remove unnecessary variables
